### PR TITLE
Use more specific var envs to be able to override api routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ npm install --save botfuel-nlp-sdk
 
 Environment variables:
 - `BOTFUEL_PROXY_HOST`: Botfuel proxy host (default to: `https://api.botfuel.io`);
-- `BOTFUEL_SPELLCHECKING_HOST`: spellchecking api host (default to `$PROXY_HOST`);
-- `BOTFUEL_SENTIMENT_ANALYSIS_HOST`: sentiment analysis api host (default to `$PROXY_HOST`);
-- `BOTFUEL_ENTITY_EXTRACTION_HOST`: entity extraction api host (default to `$PROXY_HOST`).
+- `BOTFUEL_SPELLCHECKING_API_URL`: spellchecking api url (overrides `BOTFUEL_PROXY_HOST/nlp/spellchecking`);
+- `BOTFUEL_SENTIMENT_ANALYSIS_API_URL`: sentiment analysis api url (overrides `BOTFUEL_PROXY_HOST/nlp/sentiment-analysis`);
+- `BOTFUEL_ENTITY_EXTRACTION_API_URL`: entity extraction api url (overrides `BOTFUEL_PROXY_HOST/nlp/entity-extraction`).
 
 ## How to use
 

--- a/src/config.js
+++ b/src/config.js
@@ -8,16 +8,15 @@ const baseConfig = {
 };
 
 module.exports = {
-  SPELLCHECKING_API: urlJoin(
-    process.env.BOTFUEL_SPELLCHECKING_HOST ||
-    baseConfig.PROXY_HOST, baseConfig.SPELLCHECKING_ROUTE
-  ),
-  SENTIMENT_ANALYSIS_API: urlJoin(
-    process.env.BOTFUEL_SENTIMENT_ANALYSIS_HOST ||
-    baseConfig.PROXY_HOST, baseConfig.SENTIMENT_ANALYSIS_ROUTE
-  ),
-  ENTITY_EXTRACTION_API: urlJoin(
-    process.env.BOTFUEL_ENTITY_EXTRACTION_HOST ||
-    baseConfig.PROXY_HOST, baseConfig.ENTITY_EXTRACTION_ROUTE
-  ),
+  SPELLCHECKING_API:
+    process.env.BOTFUEL_SPELLCHECKING_API_URL ||
+    urlJoin(baseConfig.PROXY_HOST, baseConfig.SPELLCHECKING_ROUTE),
+
+  SENTIMENT_ANALYSIS_API:
+    process.env.BOTFUEL_SENTIMENT_ANALYSIS_API_URL ||
+    urlJoin(baseConfig.PROXY_HOST, baseConfig.SENTIMENT_ANALYSIS_ROUTE),
+
+  ENTITY_EXTRACTION_API:
+    process.env.BOTFUEL_ENTITY_EXTRACTION_API_URL ||
+    urlJoin(baseConfig.PROXY_HOST, baseConfig.ENTITY_EXTRACTION_ROUTE),
 };


### PR DESCRIPTION
So we can use custom URLs like `BOTFUEL_SPELLCHECKING_API_URL=localhost:5000/whatever` instead of forced `localhost:5000/nlp/entity-extraction`

@kevinadda what do you think ?